### PR TITLE
Issue 96: remove GetHash from examples & minor readme cleanup

### DIFF
--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -51,7 +51,7 @@ Each helloworld process has a background goroutine performing linearizable read 
 ## Quorum ##
 As long as the majority of nodes in the Raft cluster are available, the cluster is said to has the quorum. For such a 3-nodes Raft cluster, any two nodes need to be available to have the quorum.
 
-Now press CTRL+C in any one of the terminal to stop the running exmple-helloworld program. Type in some messsages again in any of the remaining two terminals, you should still be able to have the message replicated across to the other node as the Raft cluster still has the quorum. Let's press CTRL+C to stop another instance, you should notice that further input messages will no longer be printed back on the remaining terminal and you are expected to see a timeout message. 
+Now press CTRL+C in any one of the terminal to stop the running exmple-helloworld program. Type in some messages again in any of the remaining two terminals, you should still be able to have the message replicated across to the other node as the Raft cluster still has the quorum. Let's press CTRL+C to stop another instance, you should notice that further input messages will no longer be printed back on the remaining terminal and you are expected to see a timeout message. 
 
 ```
 failed to get a proposal session, timeout
@@ -67,10 +67,10 @@ Let's pick a stopped instance and restart it using the exact same command, e.g. 
 Previously replicated messages are printed back onto the terminal again in the same order as they were initially replicated across. Dragonboat internally records the state of the node and all updates to make sure it can be correctly restored after restart. 
 
 ## Snapshotting ##
-After proposing several more messages, there will be logs mentioning that "snapshot captured". This is controled by the SnapshotEntries parameter specified in the raft.Config object. Snapshots can be used to restore the state of the program without requiring every single proposed messages to be applied one by one.
+After proposing several more messages, there will be logs mentioning that "snapshot captured". This is controlled by the SnapshotEntries parameter specified in the raft.Config object. Snapshots can be used to restore the state of the program without requiring every single proposed messages to be applied one by one.
 
 ## Membership Change ##
-In this example program, Raft cluster membership can be changed by inputing some messages with special format. The following special message causes a new node with node ID 4 running at localhost:63100 to be added to the Raft cluster.
+In this example program, Raft cluster membership can be changed by inputting some messages with special format. The following special message causes a new node with node ID 4 running at localhost:63100 to be added to the Raft cluster.
 
 ```
 add localhost:63100 4

--- a/helloworld/statemachine.go
+++ b/helloworld/statemachine.go
@@ -95,10 +95,3 @@ func (s *ExampleStateMachine) RecoverFromSnapshot(r io.Reader,
 // or release as this is a pure in memory data store. Note that the Close
 // method is not guaranteed to be called as node can crash at any time.
 func (s *ExampleStateMachine) Close() error { return nil }
-
-// GetHash returns a uint64 representing the current object state.
-func (s *ExampleStateMachine) GetHash() (uint64, error) {
-	// the only state we have is that Count variable. that uint64 value pretty much
-	// represents the state of this IStateMachine
-	return s.Count, nil
-}

--- a/multigroup/statemachine.go
+++ b/multigroup/statemachine.go
@@ -94,10 +94,3 @@ func (s *ExampleStateMachine) RecoverFromSnapshot(r io.Reader,
 // or release as this is a pure in memory data store. Note that the Close
 // method is not guaranteed to be called as node can crash at any time.
 func (s *ExampleStateMachine) Close() error { return nil }
-
-// GetHash returns a uint64 representing the current object state.
-func (s *ExampleStateMachine) GetHash() (uint64, error) {
-	// the only state we have is that Count variable. that uint64 value pretty much
-	// represents the state of this IStateMachine
-	return s.Count, nil
-}

--- a/multigroup/statemachine2.go
+++ b/multigroup/statemachine2.go
@@ -94,10 +94,3 @@ func (s *SecondStateMachine) RecoverFromSnapshot(r io.Reader,
 // or release as this is a pure in memory data store. Note that the Close
 // method is not guaranteed to be called as node can crash at any time.
 func (s *SecondStateMachine) Close() error { return nil }
-
-// GetHash returns a uint64 representing the current object state.
-func (s *SecondStateMachine) GetHash() (uint64, error) {
-	// the only state we have is that Count variable. that uint64 value pretty much
-	// represents the state of this IStateMachine
-	return s.Count, nil
-}

--- a/ondisk/diskkv.go
+++ b/ondisk/diskkv.go
@@ -559,17 +559,3 @@ func (d *DiskKV) Close() error {
 	}
 	return nil
 }
-
-// GetHash returns a hash value representing the state of the state machine.
-func (d *DiskKV) GetHash() (uint64, error) {
-	h := md5.New()
-	db := (*rocksdb)(atomic.LoadPointer(&d.db))
-	ss := db.db.NewSnapshot()
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-	if err := d.saveToWriter(db, ss, h); err != nil {
-		return 0, err
-	}
-	md5sum := h.Sum(nil)
-	return binary.LittleEndian.Uint64(md5sum[:8]), nil
-}


### PR DESCRIPTION
As the [issue](https://github.com/lni/dragonboat/issues/96) suggests, GetHash method is not used in examples and its implementation does not provide a consistent result for the same state machine, which confuses developers.

Some minor cleanups to the readme as well.