### PR TITLE
Updated Document & Variable Name in the multigroup example

### DIFF
--- a/multigroup/README.CHS.md
+++ b/multigroup/README.CHS.md
@@ -14,15 +14,15 @@ make multigroup
 在同一主机上三个不同的终端terminals上启动三个示例程序的进程：
 
 ```
-./example-multigroup -replicaid 1
+./example-multigroup -nodeid 1
 ```
 ```
-./example-multigroup -replicaid 2
+./example-multigroup -nodeid 2
 ```
 ```
-./example-multigroup -replicaid 3
+./example-multigroup -nodeid 3
 ```
-这将组建两个三节点的Raft集群，每个节点都由上述命令行命令中-replicaid所指定的ReplicaID值来标示。为求简易，本示例被设定为需用三个节点且ReplicaID值必须为1, 2, 3。
+这将组建两个三节点的Raft集群，每个节点都由上述命令行命令中-nodeid所指定的NodeID值来标示。为求简易，本示例被设定为需用三个节点且ReplicaID值必须为1, 2, 3。
 
 与之前的helloworld示例一样，你可以在一个终端上输入一条消息，它将会被复制到别的节点上。在本示例中，如果你输入一个以问好"?"结尾的消息，那么它会被提议到第二个raft组中，其余不以"?"结尾的消息均提议至第一个raft组中。
 

--- a/multigroup/README.md
+++ b/multigroup/README.md
@@ -14,15 +14,15 @@ make multigroup
 Start three instances of the example program on the same machine in three different terminals:
 
 ```
-./example-multigroup -replicaid 1
+./example-multigroup -nodeid 1
 ```
 ```
-./example-multigroup -replicaid 2
+./example-multigroup -nodeid 2
 ```
 ```
-./example-multigroup -replicaid 3
+./example-multigroup -nodeid 3
 ```
-This forms two Raft groups each with 3 nodes, nodes are identified by the ReplicaID values specified on the command line while two Raft groups are identified by the ShardID values harded coded in main.go. For simplicity, this example program has been hardcoded to use 3 nodes for each raft group and their replica id values are 1, 2 and 3.
+This forms two Raft groups each with 3 nodes, nodes are identified by the NodeID values specified on the command line while two Raft groups are identified by the ShardID values harded coded in main.go. For simplicity, this example program has been hardcoded to use 3 nodes for each raft group and their replica id values are 1, 2 and 3.
 
 Similar to the previous helloworld example, you can type in a message in one of the terminals and your input message will be replicated to other nodes. In this example, if you type something ends with a question mark "?", then that particular message is going to be proposed to the second raft group, while messages without the question mark at the end are proposed to the first raft group. 
 

--- a/multigroup/main.go
+++ b/multigroup/main.go
@@ -55,7 +55,7 @@ var (
 )
 
 func main() {
-	nodeId := flag.Int("nodeid", 1, "ReplicaID to use")
+	nodeId := flag.Int("nodeid", 1, "NodeID to use")
 	flag.Parse()
 	if *nodeId > 3 || *nodeId < 1 {
 		fmt.Fprintf(os.Stderr, "invalid nodeid %d, it must be 1, 2 or 3", *nodeId)

--- a/multigroup/main.go
+++ b/multigroup/main.go
@@ -55,10 +55,10 @@ var (
 )
 
 func main() {
-	replicaID := flag.Int("nodeid", 1, "ReplicaID to use")
+	nodeId := flag.Int("nodeid", 1, "ReplicaID to use")
 	flag.Parse()
-	if *replicaID > 3 || *replicaID < 1 {
-		fmt.Fprintf(os.Stderr, "invalid nodeid %d, it must be 1, 2 or 3", *replicaID)
+	if *nodeId > 3 || *nodeId < 1 {
+		fmt.Fprintf(os.Stderr, "invalid nodeid %d, it must be 1, 2 or 3", *nodeId)
 		os.Exit(1)
 	}
 	// https://github.com/golang/go/issues/17393
@@ -71,7 +71,7 @@ func main() {
 		// value is the raft address
 		initialMembers[uint64(idx+1)] = v
 	}
-	nodeAddr := initialMembers[uint64(*replicaID)]
+	nodeAddr := initialMembers[uint64(*nodeId)]
 	fmt.Fprintf(os.Stdout, "node address: %s\n", nodeAddr)
 	// change the log verbosity
 	logger.GetLogger("raft").SetLevel(logger.ERROR)
@@ -81,7 +81,7 @@ func main() {
 	// config for raft
 	// note the ShardID value is not specified here
 	rc := config.Config{
-		ReplicaID:          uint64(*replicaID),
+		ReplicaID:          uint64(*nodeId),
 		ElectionRTT:        5,
 		HeartbeatRTT:       1,
 		CheckQuorum:        true,
@@ -91,7 +91,7 @@ func main() {
 	datadir := filepath.Join(
 		"example-data",
 		"multigroup-data",
-		fmt.Sprintf("node%d", *replicaID))
+		fmt.Sprintf("node%d", *nodeId))
 	// config for the nodehost
 	// by default, insecure transport is used, you can choose to use Mutual TLS
 	// Authentication to authenticate both servers and clients. To use Mutual


### PR DESCRIPTION
Updated the `multigroup` document and code to use `nodeId` as the variable name, rather than `replicaID`.
