### PR TITLE
Some typo and bug fix

### DIFF
--- a/multigroup/main.go
+++ b/multigroup/main.go
@@ -55,7 +55,7 @@ var (
 )
 
 func main() {
-	replicaID := flag.Int("nodeid", 1, "ReplicaID to use")
+	replicaID := flag.Int("replicaid", 1, "ReplicaID to use")
 	flag.Parse()
 	if *replicaID > 3 || *replicaID < 1 {
 		fmt.Fprintf(os.Stderr, "invalid nodeid %d, it must be 1, 2 or 3", *replicaID)
@@ -118,7 +118,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer nh.Close()
 	// start the first cluster
 	// we use ExampleStateMachine as the IStateMachine for this cluster, its
 	// behaviour is identical to the one used in the Hello World example.


### PR DESCRIPTION
Fix inconsistency of flags in multigroup example
Fix NodeHost.Stop() called twice problem

1. In the README.md
The command has changed to `./example-multigroup -replicaid 1`, so here change the code to make it consistent between code and README.md file.


2. When we input `exit` in the console, we will hit `NodeHost.Stop() called twice` panic like below:

```
exit
panic: NodeHost.Stop called twice

goroutine 1 [running]:
github.com/lni/dragonboat/v4.(*NodeHost).Close(0xc0001bea80)
        /<home-dir>/go/pkg/mod/github.com/lni/dragonboat/v4@v4.0.0-20230917160253-d9f49378cd2d/nodehost.go:390 +0x9d0
main.main()
        /<git-repo>/dragonboat-example/multigroup/main.go:195 +0x88c
```
